### PR TITLE
feat: add theme toggle with session persistence

### DIFF
--- a/neutralino/resources/app.js
+++ b/neutralino/resources/app.js
@@ -1,4 +1,35 @@
 let currentPath = '..';
+let currentTheme = 'light';
+
+async function loadSession() {
+  try {
+    const data = await Neutralino.storage.getData('session');
+    if (data) {
+      const session = JSON.parse(data);
+      if (session.path) currentPath = session.path;
+      if (session.theme) setTheme(session.theme);
+    }
+  } catch (e) {
+    console.warn('No session', e);
+  }
+}
+
+function setTheme(theme) {
+  currentTheme = theme;
+  document.body.classList.remove('light', 'dark');
+  document.body.classList.add(theme);
+}
+
+async function saveSession() {
+  try {
+    await Neutralino.storage.setData(
+      'session',
+      JSON.stringify({ path: currentPath, theme: currentTheme })
+    );
+  } catch (e) {
+    console.error('saveSession failed', e);
+  }
+}
 
 async function scan(path) {
   try {
@@ -8,6 +39,7 @@ async function scan(path) {
     currentPath = path;
     document.getElementById('cwd').textContent = path;
     render(items);
+    await saveSession();
   } catch (e) {
     console.error(e);
   }
@@ -31,4 +63,13 @@ document.getElementById('up').addEventListener('click', () => {
   scan(currentPath + '/..');
 });
 
-scan(currentPath);
+document.getElementById('toggle-theme').addEventListener('click', () => {
+  const next = currentTheme === 'light' ? 'dark' : 'light';
+  setTheme(next);
+  saveSession();
+});
+
+(async function init() {
+  await loadSession();
+  scan(currentPath);
+})();

--- a/neutralino/resources/index.html
+++ b/neutralino/resources/index.html
@@ -10,6 +10,7 @@
   <div id="controls">
     <button id="up">Up</button>
     <span id="cwd"></span>
+    <button id="toggle-theme">Toggle Theme</button>
   </div>
   <ul id="items"></ul>
   <script src="app.js"></script>

--- a/neutralino/resources/style.css
+++ b/neutralino/resources/style.css
@@ -2,20 +2,39 @@ body {
   font-family: sans-serif;
   margin: 1rem;
 }
+
+body.light {
+  background: #fff;
+  color: #000;
+}
+
+body.dark {
+  background: #222;
+  color: #eee;
+}
+
 #controls {
   margin-bottom: 1rem;
 }
+
 #items {
   list-style: none;
   padding: 0;
 }
+
 #items li {
   padding: 4px;
 }
+
 #items li.dir {
   font-weight: bold;
   cursor: pointer;
 }
-#items li.dir:hover {
+
+body.light #items li.dir:hover {
   background: #eee;
+}
+
+body.dark #items li.dir:hover {
+  background: #333;
 }


### PR DESCRIPTION
## Summary
- add light/dark theme toggle UI and styles
- persist current folder and theme in Neutralino storage
- restore saved session on app start

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b472e512bc832ebc1fa80f895f9a2e